### PR TITLE
Fix https iframes in Sonoma insight

### DIFF
--- a/app/components/sonoma/sonoma-slide-15/template.hbs
+++ b/app/components/sonoma/sonoma-slide-15/template.hbs
@@ -17,7 +17,7 @@
       </div>
       <div class="col-md-6 wrapper">
         <div class="flex map-card">
-          <iframe src="http://resource-watch.github.io/insights/sonoma-maps/water-deficit-increases.html"></iframe>
+          <iframe src="https://resource-watch.github.io/insights/sonoma-maps/water-deficit-increases.html"></iframe>
         </div>
       </div>
     </div>

--- a/app/components/sonoma/sonoma-slide-6/template.hbs
+++ b/app/components/sonoma/sonoma-slide-6/template.hbs
@@ -11,7 +11,7 @@
       </div>
       <div class="col-md-6 wrapper">
         <div class="flex map-card">
-          <iframe src="http://resource-watch.github.io/insights/sonoma-maps/winter-air-temperature.html"></iframe>
+          <iframe src="https://resource-watch.github.io/insights/sonoma-maps/winter-air-temperature.html"></iframe>
         </div>
       </div>
     </div>

--- a/app/components/sonoma/sonoma-slide-8/template.hbs
+++ b/app/components/sonoma/sonoma-slide-8/template.hbs
@@ -14,7 +14,7 @@
       </div>
       <div class="col-md-6 wrapper">
         <div class="flex map-card">
-          <iframe src="http://resource-watch.github.io/insights/sonoma-maps/summer-air-temperature.html"></iframe>
+          <iframe src="https://resource-watch.github.io/insights/sonoma-maps/summer-air-temperature.html"></iframe>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Since we've moved to https; http iframes are broken.

The Sonoma insight is a static rendering of this repo hosted at 
http://github.com/resource-watch/insights